### PR TITLE
Certificates from the code

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install required packages
+        run: |
+          sudo apt update
+          sudo apt install libev-dev -y
       - name: Install tox
         run: pip install tox
       - name: Black

--- a/README.md
+++ b/README.md
@@ -8,9 +8,28 @@ pip install gcl_certbot_plugin
 
 # Create certificate
 certbot certonly --authenticator=genesis-core \
-    --genesis-core-endpoint=http://local.genesis-core.tech:11010/v1 \
+    --genesis-core-endpoint=http://core.local.genesis-core.tech:11010 \
     --genesis-core-login=admin \
     --genesis-core-password=password \
     --domains test.pdns.your.domain
 ```
 
+To create a new certificate, in the code
+```python
+from gcl_certbot_plugin import acme
+
+# Get or creat a client private key
+private_key = acme.get_or_create_client_private_key("privkey.pem")
+
+# Get ACME client
+client_acme = acme.get_acme_client(private_key, "myemail@example.com")
+
+# Create cert
+pkey_pem, csr_pem, fullchain_pem = acme.create_cert(
+    client_acme,
+    dns_client,
+    ["test.pdns.your.domain"],
+)
+```
+
+For complete example see [create_cert](https://github.com/infraguys/gcl_certbot_plugin/blob/master/gcl_certbot_plugin/examples/create_cert.py) script.

--- a/gcl_certbot_plugin/acme.py
+++ b/gcl_certbot_plugin/acme.py
@@ -1,0 +1,281 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import os
+import logging
+import typing as tp
+
+from acme import challenges
+from acme import client as acme_lib_client
+from acme import crypto_util
+from acme import errors
+from acme import messages
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import josepy as jose
+
+from gcl_certbot_plugin import clients as dns_clients
+
+LOG = logging.getLogger(__name__)
+
+
+# This is the staging point for ACME-V2 within Let's Encrypt.
+DIRECTORY_URL = "https://acme-staging-v02.api.letsencrypt.org/directory"
+USER_AGENT = "python-acme-example"
+
+# Account key size
+ACC_KEY_BITS = 2048
+
+# Certificate private key size
+CERT_PKEY_BITS = 2048
+
+
+def get_or_create_client_private_key(key_path: str) -> rsa.RSAPrivateKey:
+    """Get or create a client private key."""
+    # Try to get the private key
+    if os.path.exists(key_path):
+        with open(key_path, "rb") as f:
+            return serialization.load_pem_private_key(
+                f.read(), password=None, backend=default_backend()
+            )
+
+    # If it doesn't exist, create it
+    os.makedirs(os.path.dirname(key_path), exist_ok=True)
+
+    new_client_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=ACC_KEY_BITS, backend=default_backend()
+    )
+    raw_client_key = new_client_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    # Save the private key
+    with open(key_path, "wb") as f:
+        f.write(raw_client_key)
+
+    return serialization.load_pem_private_key(
+        raw_client_key, password=None, backend=default_backend()
+    )
+
+
+def get_acme_client(
+    private_client_key: rsa.RSAPrivateKey,
+    email: str,
+    user_agent: str = USER_AGENT,
+    directory_url: str = DIRECTORY_URL,
+) -> acme_lib_client.ClientV2:
+    """Get ACME client."""
+    acc_key = jose.JWKRSA(key=private_client_key)
+
+    net = acme_lib_client.ClientNetwork(acc_key, user_agent=user_agent)
+    directory = acme_lib_client.ClientV2.get_directory(directory_url, net)
+    client = acme_lib_client.ClientV2(directory, net=net)
+
+    try:
+        client.net.account = client.new_account(
+            messages.NewRegistration.from_data(
+                email=email,
+                terms_of_service_agreed=True,
+                only_return_existing=True,
+            )
+        )
+    except errors.ConflictError as e:
+        account_url = e.location
+        LOG.info("Account already exists: %s", account_url)
+
+        client.net.account = messages.RegistrationResource(
+            body=messages.Registration(
+                terms_of_service_agreed=True, only_return_existing=True
+            ),
+            uri=account_url,
+        )
+
+    return client
+
+
+def new_csr_comp(
+    domains_name: tp.Collection[str], pkey_pem: bytes | None = None
+) -> tuple[bytes, bytes]:
+    """Create certificate signing request."""
+    if pkey_pem is None:
+        # Create private key.
+        pkey = rsa.generate_private_key(
+            public_exponent=65537, key_size=CERT_PKEY_BITS
+        )
+        pkey_pem = pkey.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    csr_pem = crypto_util.make_csr(pkey_pem, list(domains_name))
+    return pkey_pem, csr_pem
+
+
+def select_dns01_chall(
+    orderr: messages.OrderResource,
+) -> list[challenges.DNS01]:
+    """Extract authorization resource from within order resource."""
+    # Authorization Resource: authz.
+    # This object holds the offered challenges by the server and their status.
+    authz_list = orderr.authorizations
+    chs = []
+
+    for authz in authz_list:
+        # Choosing challenge.
+        # authz.body.challenges is a set of ChallengeBody objects.
+        for i in authz.body.challenges:
+            # Find the supported challenge.
+            if isinstance(i.chall, challenges.DNS01):
+                chs.append(i)
+
+    if len(chs) > 0:
+        return chs
+
+    raise RuntimeError("DNS-01 challenge was not offered by the CA server.")
+
+
+def dns_records_for_challenge(
+    domains: tp.Collection[str],
+    dns_client: dns_clients.TinyDNSCoreClient,
+    validation: str,
+) -> list[dict[str, tp.Any]]:
+    records = []
+    domain_set = set(domains)
+    domains_for_challenge = []
+
+    # Don't create wildcard TXT records
+    # Example:
+    # 1) ["example.com", "*.example.com"] -> ["example.com"]
+    # 2) ["*.example.com"] -> ["example.com"]
+    for domain in domains:
+        if not domain.startswith("*."):
+            domains_for_challenge.append(domain)
+            continue
+
+        # Add the direct domain for wildcard domain if it doesn't exist
+        direct_domain = domain.split(".", 1)[1]
+        if direct_domain not in domain_set:
+            domains_for_challenge.append(direct_domain)
+
+    # Go to Core DNS and add TXT record
+    for domain in domains_for_challenge:
+        record = dns_client.create_txt_record(
+            domain, validation, "_acme-challenge"
+        )
+        records.append(record)
+
+    return records
+
+
+def perform_dns01(
+    domains: tp.Collection[str],
+    acme_client: acme_lib_client.ClientV2,
+    dns_client: dns_clients.TinyDNSCoreClient,
+    challbs: list[challenges.DNS01],
+    orderr: messages.OrderResource,
+) -> str:
+    """Set up standalone webserver and perform DNS-01 challenge."""
+
+    # Go to Core DNS and add TXT records
+    records = []
+
+    try:
+        for challb in challbs:
+            # Get DNS-01 challenge
+            response, validation = challb.response_and_validation(
+                acme_client.net.key
+            )
+
+            records += dns_records_for_challenge(
+                domains, dns_client, validation
+            )
+
+            # Let the CA server know that we are ready for the challenge.
+            acme_client.answer_challenge(challb, response)
+
+        # Wait for challenge status and then issue a certificate.
+        # It is possible to set a deadline time.
+        finalized_orderr = acme_client.poll_and_finalize(orderr)
+
+        return finalized_orderr.fullchain_pem
+    finally:
+        # Clean up TXT records
+        for record in records:
+            domain_uuid = record["domain"].split("/")[-1]
+            record_uuid = record["uuid"]
+            dns_client.delete_record(domain_uuid, record_uuid)
+
+
+def create_cert(
+    acme_client: acme_lib_client.ClientV2,
+    dns_client: dns_clients.TinyDNSCoreClient,
+    domains: tp.Collection[str],
+) -> tuple[bytes, bytes, str]:
+    """Issue a new certificate."""
+    # Create domain private key and CSR
+    pkey_pem, csr_pem = new_csr_comp(domains)
+
+    # Issue certificate
+    orderr = acme_client.new_order(csr_pem)
+
+    # Select DNS-01 within offered challenges by the CA server
+    challbs = select_dns01_chall(orderr)
+
+    # The certificate is ready to be used in the variable "fullchain_pem".
+    fullchain_pem = perform_dns01(
+        domains, acme_client, dns_client, challbs, orderr
+    )
+
+    return pkey_pem, csr_pem, fullchain_pem
+
+
+def renew_cert(
+    acme_client: acme_lib_client.ClientV2,
+    dns_client: dns_clients.TinyDNSCoreClient,
+    domains: tp.Collection[str],
+    pkey_pem: bytes,
+) -> tuple[bytes, bytes, str]:
+    """Renew the certificate with the specified private key."""
+    _, csr_pem = new_csr_comp(domains, pkey_pem)
+    orderr = acme_client.new_order(csr_pem)
+    challbs = select_dns01_chall(orderr)
+
+    # Performing challenge
+    fullchain_pem = perform_dns01(
+        domains, acme_client, dns_client, challbs, orderr
+    )
+
+    return pkey_pem, csr_pem, fullchain_pem
+
+
+def revoke_cert(
+    acme_client: acme_lib_client.ClientV2, fullchain_pem: str
+) -> None:
+    """Revoke the certificate."""
+    fullchain_com = x509.load_pem_x509_certificate(fullchain_pem.encode())
+
+    try:
+        # revocation reason = 0
+        acme_client.revoke(fullchain_com, 0)
+    except errors.ConflictError:
+        # Certificate already revoked.
+        pass

--- a/gcl_certbot_plugin/clients.py
+++ b/gcl_certbot_plugin/clients.py
@@ -1,0 +1,93 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import uuid as sys_uuid
+import typing as tp
+
+import bazooka
+
+from gcl_sdk.clients.http import base
+
+
+class TinyDNSCoreClient:
+    def __init__(
+        self,
+        base_url: str,
+        http_client: bazooka.Client | None = None,
+        auth: base.AbstractAuthenticator | None = None,
+    ) -> None:
+        http_client = http_client or bazooka.Client()
+        self._http_client = http_client
+        self._base_url = base_url
+        self._auth = auth
+        self._domains_client = base.CollectionBaseClient(
+            self._base_url, self._http_client, self._auth
+        )
+        self._records_client = base.CollectionBaseClient(
+            self._base_url, self._http_client, self._auth
+        )
+
+    @property
+    def domains(self) -> base.CollectionBaseClient:
+        return self._domains_client
+
+    @property
+    def records(self) -> base.CollectionBaseClient:
+        return self._records_client
+
+    def create_txt_record(
+        self, domain: str, content: str, prefix: str = ""
+    ) -> dict[str, tp.Any]:
+        parent_domain = domain
+        domains_collection = "/v1/dns/domains/"
+
+        # Try to find target zone iteratively.
+        while parent_domain:
+            try:
+                parent_domain = parent_domain.split(".", 1)[1]
+            except IndexError:
+                raise ValueError(
+                    f"Could not find DNS zone for domain {domain}"
+                )
+
+            domains = self.domains.filter(
+                domains_collection, name=parent_domain
+            )
+            if domains:
+                name = domain[: -len(parent_domain)]
+                zone = domains[0]
+                break
+
+        if prefix:
+            name = f"{prefix}.{name}"
+
+        data = {
+            "type": "TXT",
+            "ttl": 0,
+            "record": {
+                "kind": "TXT",
+                "name": name,
+                "content": content,
+            },
+        }
+
+        records_collection = f"/v1/dns/domains/{zone["uuid"]}/records/"
+        return self.records.create(records_collection, data)
+
+    def delete_record(
+        self, domain: sys_uuid.UUID, record: sys_uuid.UUID
+    ) -> None:
+        records_collection = f"/v1/dns/domains/{domain}/records/"
+        self.records.delete(records_collection, record)

--- a/gcl_certbot_plugin/examples/create_cert.py
+++ b/gcl_certbot_plugin/examples/create_cert.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import argparse
+
+from cryptography import x509
+from gcl_sdk.clients.http import base as core_client_base
+
+from gcl_certbot_plugin import acme
+from gcl_certbot_plugin import clients as dns_clients
+
+
+DEFAULT_PRIVATE_KEY_PATH = "/etc/genesis_core/certbot/privkey.pem"
+
+
+def issue_cert_dns_core(
+    domains: list[str],
+    email: str,
+    dns_client: dns_clients.TinyDNSCoreClient,
+    private_key_path: str = DEFAULT_PRIVATE_KEY_PATH,
+) -> None:
+    """A simple example to issue a cert via Genesis Core DNS."""
+    private_key = acme.get_or_create_client_private_key(private_key_path)
+
+    print(f"Loaded private key from: {private_key_path}")
+
+    client_acme = acme.get_acme_client(private_key, email)
+
+    print(f"The ACME client is ready: {client_acme}")
+
+    pkey_pem, csr_pem, fullchain_pem = acme.create_cert(
+        client_acme,
+        dns_client,
+        domains,
+    )
+
+    print("The cert generated!")
+    print("============ pkey ===============")
+    print(pkey_pem.decode())
+    print("=========== csr_pem ===============")
+    print(csr_pem.decode())
+    print("============ fullchain ===============")
+    print(fullchain_pem)
+    print("============ valid ===============")
+    cert = x509.load_pem_x509_certificate(fullchain_pem.encode())
+    print("Before: ", cert.not_valid_before_utc.isoformat())
+    print("After: ", cert.not_valid_after_utc.isoformat())
+
+
+if __name__ == "__main__":
+    """A simple example to issue a cert via Genesis Core DNS.
+    
+    Usage:
+
+    python create_cert.py \
+        --domain test.pdns.your.domain \
+        --email admin@genesis-core.tech \
+        --endpoint http://10.20.0.2:11010
+        --core-user test \
+        --core-password test
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--domain", type=str, required=True)
+    parser.add_argument(
+        "--email", type=str, default="admin@genesis-core.tech", required=True
+    )
+    parser.add_argument("-l", "--endpoint", type=str, required=True)
+    parser.add_argument("-u", "--core-user", type=str, required=True)
+    parser.add_argument("-p", "--core-password", type=str, required=True)
+    args = parser.parse_args()
+
+    domains = [args.domain]
+
+    auth = core_client_base.CoreIamAuthenticator(
+        args.endpoint, args.core_user, args.core_password
+    )
+    dns_client = dns_clients.TinyDNSCoreClient(
+        base_url=args.endpoint, auth=auth
+    )
+
+    print(f"Issue a cert for domains: {domains}")
+
+    issue_cert_dns_core(domains, args.email, dns_client)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pbr>=1.10.0,<=5.8.1  # Apache-2.0
 bazooka>=1.3.0,<2.0.0  # Apache-2.0
 certbot>=3.0.0,<5.0.0  # Apache-2.0
 gcl_iam>=0.11.0,<1.0.0  # Apache-2.0
+gcl_sdk>=0.4.0,<1.0.0  # Apache-2.0
+cryptography>=45.0.5,<47.0.0 # BSD-3


### PR DESCRIPTION
Added ability to use the plugin as a module that helps to manage certificates from the code and not only as a CLI tool.

- acme - it's a module with functions to work with letsencrypted API.
- clients - it a module with clients for Genesis Core.
- create_cert - a simple tool/example the demonstrate how to use it.